### PR TITLE
Mx93 symphony

### DIFF
--- a/carrier_eeprom.sh
+++ b/carrier_eeprom.sh
@@ -51,6 +51,9 @@ elif [ `grep i.MX8QXP /sys/devices/soc0/soc_id` ]; then
 		I2C_BUS=2
 elif [ `grep i.MX8QM /sys/devices/soc0/soc_id` ]; then
 		I2C_BUS=4
+elif [ `grep i.MX93 /sys/devices/soc0/soc_id` ]; then
+		EEPROM_IMAGE_DIR=/run/media/imx_kit_test-sda1/carrier_eeprom
+		I2C_BUS=0
 else
 	echo "Unsupported SOM"
 	exit 1


### PR DESCRIPTION
There are two sets of changes in this PR:
1. For the carrier EEPROM
Testing: I verified that the EEPROM was getting rewritten with i2cdump after calling the script.

2. For the imx_kit_test.sh tests:
Testing: The output of the test script is seen below:
```
root@imx93-var-som:/run/media/imx_kit_test-sda1# ./imx_kit_test.sh                  
Memory: OK

Hit Enter to test sound
***********************

Testing Ethernet
****************
[  290.583822] audit: type=1334 audit(1677178793.290:24): prog-id=19 op=LOAD
[  290.593425] audit: type=1334 audit(1677178793.298:25): prog-id=20 op=LOAD
Ethernet: OK

Testing Ethernet 2
******************
[  297.681662] ADIN1300 stmmac-0:05: attached PHY driver (mii_bus:phy_addr=stmmac-0:05, irq=POLL)
[  297.698299] imx-dwmac 428a0000.ethernet eth0: Link is Down
[  297.704920] imx-dwmac 428a0000.ethernet eth0: FPE workqueue stop
[  297.741660] imx-dwmac 428a0000.ethernet eth0: PHY [stmmac-0:00] driver [ADIN1300] (irq=POLL)
[  297.750127] imx-dwmac 428a0000.ethernet eth0: configuring for phy/rgmii link mode
[  301.781414] fec 42890000.ethernet eth1: Link is Up - 1Gbps/Full - flow control rx/tx
[  301.789209] IPv6: ADDRCONF(NETDEV_CHANGE): eth1: link becomes ready
Ethernet_2: OK

Testing WiFi
************
[  306.904353] IPv6: ADDRCONF(NETDEV_CHANGE): wlan0: link becomes ready
WiFi Association: OK
WiFi ping: OK

Testing bluetooth
*****************
Bluetooth scan: OK
Bluetooth ping: OK

USB: OK
Working USB ports:
    |__ Port 1: Dev 2, If 0, Class=Mass Storage, Driver=usb-storage, 480M
        |__ Port 1: Dev 4, If 0, Class=Mass Storage, Driver=usb-storage, 480M

Flip the USB type C cable in the receptacle and hit Enter to continue
*********************************************************************
[  334.671612] usb 1-1: USB disconnect, device number 2
[  334.676622] usb 1-1.1: USB disconnect, device number 4
[  334.682029] ci_hdrc ci_hdrc.0: remove, state 1
[  334.686900] usb usb1: USB disconnect, device number 1
[  334.738264] usb 1-1.2: USB disconnect, device number 3
[  334.751295] ci_hdrc ci_hdrc.0: USB bus 1 deregistered
[  334.953582] audit: type=1334 audit(1677178837.660:26): prog-id=0 op=UNLOAD
[  334.960493] audit: type=1334 audit(1677178837.660:27): prog-id=0 op=UNLOAD
[  344.935472] ci_hdrc ci_hdrc.0: EHCI Host Controller
[  344.940438] ci_hdrc ci_hdrc.0: new USB bus registered, assigned bus number 1
[  344.965824] ci_hdrc ci_hdrc.0: USB 2.0 started, EHCI 1.00
[  344.971821] hub 1-0:1.0: USB hub found 
[  344.977114] hub 1-0:1.0: 1 port detected
[  346.414310] usb 1-1: new high-speed USB device number 2 using ci_hdrc
[  346.577067] hub 1-1:1.0: USB hub found
[  346.581145] hub 1-1:1.0: 4 ports detected
[  347.501917] usb 1-1.2: new full-speed USB device number 3 using ci_hdrc
[  347.677027] usb 1-1.2: not running at top speed; connect to a high speed hub
[  348.957982] usb 1-1.1: new high-speed USB device number 4 using ci_hdrc
[  349.130851] usb-storage 1-1.1:1.0: USB Mass Storage device detected
[  349.137654] scsi host1: usb-storage 1-1.1:1.0
[  350.168210] scsi 1:0:0:0: Direct-Access     Generic  Flash Disk       8.07 PQ: 0 ANSI: 4
[  350.180662] sd 1:0:0:0: [sdb] 7866368 512-byte logical blocks: (4.03 GB/3.75 GiB)
[  350.189175] sd 1:0:0:0: [sdb] Write Protect is off
[  350.195040] sd 1:0:0:0: [sdb] Write cache: disabled, read cache: enabled, doesn't support DPO or FUA
[  350.212653]  sdb: sdb1
[  350.222806] sd 1:0:0:0: [sdb] Attached SCSI removable disk

USB: OK
Working USB ports:
    |__ Port 1: Dev 2, If 0, Class=Mass Storage, Driver=usb-storage, 480M
        |__ Port 1: Dev 4, If 0, Class=Mass Storage, Driver=usb-storage, 480M

Hit Enter to test backlight
***************************

[  360.496383] imx-dwmac 428a0000.ethernet eth0: PHY [stmmac-0:00] driver [ADIN1300] (irq=POLL)
[  360.505820] imx-dwmac 428a0000.ethernet eth0: Register MEM_TYPE_PAGE_POOL RxQ-0
[  360.522428] imx-dwmac 428a0000.ethernet eth0: No Safety Features support found
[  360.529687] imx-dwmac 428a0000.ethernet eth0: IEEE 1588-2008 Advanced Timestamp supported
[  360.538654] imx-dwmac 428a0000.ethernet eth0: registered PTP clock
[  360.545109] imx-dwmac 428a0000.ethernet eth0: FPE workqueue start
[  360.551402] imx-dwmac 428a0000.ethernet eth0: configuring for phy/rgmii link mode
[  360.562961] 8021q: adding VLAN 0 to HW filter on device eth0
[  360.644398] ADIN1300 stmmac-0:05: attached PHY driver (mii_bus:phy_addr=stmmac-0:05, irq=POLL)
I2C0: OK
I2C2: OK

Clock: OK

Click on all buttons to test them (be carefull with the reset button)
*********************************************************************
Input driver version is 1.0.1                                                                                                                                          
Input device ID: bus 0x19 vendor 0x0 product 0x0 version 0x0                                                                                                           
Input device name: "44440000.bbnsm:pwrkey"                                                                                                                             
Supported events:                                                                                                                                                      
  Event type 0 (EV_SYN)
  Event type 1 (EV_KEY)
    Event code 116 (KEY_POWER)
Properties:
Testing ... (interrupt to exit)
Input driver version is 1.0.1
Input device ID: bus 0x19 vendor 0x1 product 0x1 version 0x100
Input device name: "gpio-keys"
Supported events:
  Event type 0 (EV_SYN)
  Event type 1 (EV_KEY)
    Event code 102 (KEY_HOME)
    Event code 139 (KEY_MENU)
    Event code 158 (KEY_BACK)
Properties:
Testing ... (interrupt to exit)
root@imx93-var-som:/run/media/imx_kit_test-sda1# [  363.640351] imx-dwmac 428a0000.ethernet eth0: Link is Up - 1Gbps/Full - flow control rx/tx
[  363.648664] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[  363.729869] audit: type=1334 audit(1677178866.431:28): prog-id=21 op=LOAD
[  363.737739] audit: type=1334 audit(1677178866.443:29): prog-id=22 op=LOAD
[  363.746907] fec 42890000.ethernet eth1: Link is Up - 1Gbps/Full - flow control rx/tx
[  363.754740] IPv6: ADDRCONF(NETDEV_CHANGE): eth1: link becomes ready
Event: time 1677178869.953530, type 1 (EV_KEY), code 158 (KEY_BACK), value 1
Event: time 1677178869.953530, -------------- SYN_REPORT ------------
Event: time 1677178870.129531, type 1 (EV_KEY), code 158 (KEY_BACK), value 0
Event: time 1677178870.129531, -------------- SYN_REPORT ------------
Event: time 1677178870.761521, type 1 (EV_KEY), code 102 (KEY_HOME), value 1
Event: time 1677178870.761521, -------------- SYN_REPORT ------------
Event: time 1677178870.929525, type 1 (EV_KEY), code 102 (KEY_HOME), value 0
Event: time 1677178870.929525, -------------- SYN_REPORT ------------
Event: time 1677178871.621532, type 1 (EV_KEY), code 139 (KEY_MENU), value 1
Event: time 1677178871.621532, -------------- SYN_REPORT ------------
Event: time 1677178871.785527, type 1 (EV_KEY), code 139 (KEY_MENU), value 0
Event: time 1677178871.785527, -------------- SYN_REPORT ------------Event: time 1677178871.785527, -------------- SYN_REPORT ------------
[  394.171604] audit: type=1334 audit(1677178896.874:30): prog-id=0 op=UNLOAD
[  394.178528] audit: type=1334 audit(1677178896.874:31): prog-id=0 op=UNLOAD

```